### PR TITLE
Remove jq dependency and sanitize the site name

### DIFF
--- a/mutagen
+++ b/mutagen
@@ -8,38 +8,40 @@ function require_program {
 }
 
 require_program "mutagen"
-require_program "jq"
+
+# Prevent invalid session name errors.
+SANITIZED_SITENAME=${DDEV_SITENAME//[^a-zA-Z0-9]/}
 
 if [ "$1" == "start" ]; then
     # Don't recreate mutagen sync if it already exists.
-    if [ -f ".ddev/.mutagen-sync-name" ]; then
+    if [ -f ${DDEV_APPROOT}/.ddev/.mutagen-sync-name ]; then
         echo "Mutagen sync appears to already be running"
         exit 0
     fi
 
     # Clear out the test files that are bundled with the web container.
-    ddev exec --dir /var/www rm phpstatus.php
-    ddev exec --dir /var/www rm -r html/docroot/test
+    ddev exec --dir /var/www rm -f phpstatus.php
+    ddev exec --dir /var/www rm -r -f html/${DDEV_DOCROOT}/test
 
     # Make sure the mutagen daemon is running.
     # If the daemon is already running, this will fail, but that's okay.
     mutagen daemon start 2>/dev/null
 
-    # Create the sync process from the ddev project name
-    ddev describe -j | jq -r .raw.name > .ddev/.mutagen-sync-name
-    if ! mutagen sync list $(cat .ddev/.mutagen-sync-name) 2>/dev/null; then
-        mutagen sync create . docker://ddev-$(cat .ddev/.mutagen-sync-name)-web/var/www/html --sync-mode=two-way-resolved --symlink-mode=posix-raw --name=$(cat .ddev/.mutagen-sync-name)
+    # Create the sync process from the ddev project name.
+    echo $SANITIZED_SITENAME > ${DDEV_APPROOT}/.ddev/.mutagen-sync-name
+    if ! mutagen sync list $SANITIZED_SITENAME 2>/dev/null; then
+        mutagen sync create . docker://ddev-${DDEV_SITENAME}-web/var/www/html --sync-mode=two-way-resolved --symlink-mode=posix-raw --name=$SANITIZED_SITENAME
     fi
 
-    # Wait for the initial sync process to complete, watch for errors, and return
-    # when ready.
+    # Wait for the initial sync process to complete, watch for errors, and
+    # return when ready.
     echo "Waiting for initial sync to complete"
     while true; do
-        if mutagen sync list $(cat .ddev/.mutagen-sync-name) | grep "Last error"; then
-            echo "Mutagen sync has errored -- check 'mutagen sync list $(cat .ddev/.mutagen-sync-name)' for the problem"
+        if mutagen sync list $SANITIZED_SITENAME | grep "Last error"; then
+            echo "Mutagen sync has errored -- check 'mutagen sync list $SANITIZED_SITENAME' for the problem"
             break
         fi
-        if mutagen sync list $(cat .ddev/.mutagen-sync-name) | grep "Status: Watching for changes"; then
+        if mutagen sync list $SANITIZED_SITENAME | grep "Status: Watching for changes"; then
             echo "Initial mutagen sync has completed. Happy coding!"
             break
         fi
@@ -50,6 +52,6 @@ fi
 
 if [ "$1" == "stop" ]; then
     echo "Ending mutagen sync process"
-    mutagen sync terminate $(cat .ddev/.mutagen-sync-name)
+    mutagen sync terminate $SANITIZED_SITENAME
     rm .ddev/.mutagen-sync-name
 fi

--- a/setup.sh
+++ b/setup.sh
@@ -11,18 +11,12 @@ if [ ! -d ".ddev" ]; then
   exit 1
 fi
 
-echo "=> Checking to make sure mutagen and jq are installed"
+echo "=> Checking to make sure mutagen is installed"
 if ! type "mutagen" > /dev/null 2>&1; then
   echo "  => mutagen is not installed. running 'brew install mutagen-io/mutagen/mutagen'"
   echo "     If you do not want to do this, press Ctrl+C in the next 5 seconds"
   sleep 5
   brew install mutagen-io/mutagen/mutagen
-fi
-if ! type "jq" > /dev/null 2>&1; then
-  echo "  => jq is not installed. running 'brew install jq'"
-  echo "     If you do not want to do this, press Ctrl+C in the next 5 seconds"
-  sleep 5
-  brew install jq
 fi
 
 echo "=> Setting up mutagen sync script in the current ddev project"


### PR DESCRIPTION
Thank you very much for your work!

I have been doing tests and I have encountered the following problems:
* If a site has a character such as a dot, it is impossible to start mutagen
* It cannot create the `.ddev/.mutagen-sync-name` file, if you are not at the root of the project.

I have made some changes that I hope may be helpful.

Please tell me if something is not correct.

```
# ddev mutagen start
rm: cannot remove 'phpstatus.php': No such file or directory
Failed to execute command rm phpstatus.php: exit status 1
rm: cannot remove 'html/docroot/test': No such file or directory
Failed to execute command rm -r html/docroot/test: exit status 1
Error: invalid session name: invalid name character at index 2: '.'
Waiting for initial sync to complete
Error: list failed: unable to locate requested sessions: specification "d8.dev" did not match any sessions
```