### PR TITLE
Simplify and improve both scripts, fixes #5, replaces #1

### DIFF
--- a/mutagen
+++ b/mutagen
@@ -28,7 +28,7 @@ if [ "$1" == "start" ]; then
     ddev exec rm -rf /var/www/html/{test,index.html}
 
     # Create the sync process from the ddev project
-    mutagen sync create ${DDEV_DOCROOT} docker://ddev-${project_name}-web/var/www/html --sync-mode=two-way-resolved --symlink-mode=posix-raw --name=${sync_name}
+    mutagen sync create ${DDEV_APPROOT} docker://ddev-${project_name}-web/var/www/html --sync-mode=two-way-resolved --symlink-mode=posix-raw --name=${sync_name}
 
     # Wait for the initial sync process to complete, watch for errors, and return
     # when ready.

--- a/mutagen
+++ b/mutagen
@@ -6,7 +6,8 @@
 
 set -eu -o pipefail
 
-project_name=${DDEV_PROJECT}
+# Mutagen sync names can't have '.' but ddev projects can...
+project_name=${DDEV_PROJECT//.}
 
 if ! command -v mutagen >/dev/null 2>&1; then
         echo "mutagen is required. Please install it and try again."

--- a/mutagen
+++ b/mutagen
@@ -47,8 +47,8 @@ if [ "$1" == "start" ]; then
     done
 fi
 
-if [ "$1" == "stop" ]; then
-    echo "Ending mutagen sync process"
+if [ "$1" == "stop" -o "$1" == "pause" ]; then
+    echo "Stopping mutagen sync process"
     mutagen sync flush ${sync_name}
     mutagen sync terminate ${sync_name}
 fi

--- a/mutagen
+++ b/mutagen
@@ -27,7 +27,8 @@ if [ "$1" == "start" ]; then
     fi
 
     # Clear out the test files that are bundled with the web container.
-    ddev exec --dir /var/www rm -r phpstatus.php html/test
+    # We don't want those synced back into the project
+    ddev exec rm -rf /var/www/html/{test,index.html}
 
     # Create the sync process from the ddev project
     mutagen sync create . docker://ddev-${project_name}-web/var/www/html --sync-mode=two-way-resolved --symlink-mode=posix-raw --name=${project_name}

--- a/mutagen
+++ b/mutagen
@@ -7,7 +7,8 @@
 set -eu -o pipefail
 
 # Mutagen sync names can't have '.' but ddev projects can...
-project_name=${DDEV_PROJECT//.}
+project_name=${DDEV_PROJECT}
+sync_name=${project_name//.}
 
 if ! command -v mutagen >/dev/null 2>&1; then
         echo "mutagen is required. Please install it and try again."
@@ -20,24 +21,24 @@ mutagen daemon start
 if [ "$1" == "start" ]; then
     # If there's an existing sync, terrible things can happen, see
     # https://github.com/mutagen-io/mutagen/issues/275 and make sure that doesn't happen
-    mutagen sync terminate ${project_name} 2>/dev/null || true
+    mutagen sync terminate ${sync_name} 2>/dev/null || true
 
     # Clear out test files that are bundled with the web container.
     # We don't want those synced back into the project
     ddev exec rm -rf /var/www/html/{test,index.html}
 
     # Create the sync process from the ddev project
-    mutagen sync create ${DDEV_DOCROOT} docker://ddev-${project_name}-web/var/www/html --sync-mode=two-way-resolved --symlink-mode=posix-raw --name=${project_name}
+    mutagen sync create ${DDEV_DOCROOT} docker://ddev-${project_name}-web/var/www/html --sync-mode=two-way-resolved --symlink-mode=posix-raw --name=${sync_name}
 
     # Wait for the initial sync process to complete, watch for errors, and return
     # when ready.
     echo "Waiting for initial sync to complete"
     while true; do
-        if mutagen sync list ${project_name} | grep "Last error"; then
+        if mutagen sync list ${sync_name} | grep "Last error"; then
             echo "Mutagen sync has errored -- check 'mutagen sync list $(cat ${mutagen_sync_file})' for the problem"
             break
         fi
-        if mutagen sync list ${project_name} | grep "Status: Watching for changes" >/dev/null; then
+        if mutagen sync list ${sync_name} | grep "Status: Watching for changes" >/dev/null; then
             echo "Initial mutagen sync has completed. Happy coding!"
             break
         fi
@@ -48,6 +49,6 @@ fi
 
 if [ "$1" == "stop" ]; then
     echo "Ending mutagen sync process"
-    mutagen sync flush ${project_name}
-    mutagen sync terminate ${project_name}
+    mutagen sync flush ${sync_name}
+    mutagen sync terminate ${sync_name}
 fi

--- a/mutagen
+++ b/mutagen
@@ -26,7 +26,7 @@ if [ "$1" == "start" ]; then
         exit 0
     fi
 
-    # Clear out the test files that are bundled with the web container.
+    # Clear out test files that are bundled with the web container.
     # We don't want those synced back into the project
     ddev exec rm -rf /var/www/html/{test,index.html}
 

--- a/mutagen
+++ b/mutagen
@@ -31,7 +31,7 @@ if [ "$1" == "start" ]; then
     ddev exec rm -rf /var/www/html/{test,index.html}
 
     # Create the sync process from the ddev project
-    mutagen sync create . docker://ddev-${project_name}-web/var/www/html --sync-mode=two-way-resolved --symlink-mode=posix-raw --name=${project_name}
+    mutagen sync create ${DDEV_DOCROOT} docker://ddev-${project_name}-web/var/www/html --sync-mode=two-way-resolved --symlink-mode=posix-raw --name=${project_name}
 
     # Wait for the initial sync process to complete, watch for errors, and return
     # when ready.

--- a/mutagen
+++ b/mutagen
@@ -1,30 +1,25 @@
 #!/bin/bash
+
 ## Description: Runs mutagen on the current project
-## Usage: mutagen
+## Usage: mutagen [start|stop]
 ## Example: "ddev mutagen start" or "ddev mutagen stop"
 
 set -eu -o pipefail
 
-project_name=$(ddev describe -j | jq -r .raw.name)
+project_name=${DDEV_PROJECT}
 
-function require_program {
-    if ! type "$1" > /dev/null 2>&1; then
-        echo "$1 is required. Please install it and try again."
+if ! command -v mutagen >/dev/null 2>&1; then
+        echo "mutagen is required. Please install it and try again."
         exit 1
-    fi
-}
-
-require_program "mutagen"
-require_program "jq"
+fi
 
 # Make sure the mutagen daemon is running.
 mutagen daemon start
 
 if [ "$1" == "start" ]; then
-    if mutagen sync list ${project_name} 2>/dev/null; then
-        echo "Mutagen sync for ${project_name} is already running"
-        exit 0
-    fi
+    # If there's an existing sync, terrible things can happen, see
+    # https://github.com/mutagen-io/mutagen/issues/275 and make sure that doesn't happen
+    mutagen sync terminate ${project_name} 2>/dev/null || true
 
     # Clear out test files that are bundled with the web container.
     # We don't want those synced back into the project

--- a/mutagen
+++ b/mutagen
@@ -1,7 +1,11 @@
 #!/bin/bash
 ## Description: Runs mutagen on the current project
 ## Usage: mutagen
-## Example: "ddev mutagen"
+## Example: "ddev mutagen start" or "ddev mutagen stop"
+
+set -eu -o pipefail
+
+project_name=$(ddev describe -j | jq -r .raw.name)
 
 function require_program {
     if ! type "$1" > /dev/null 2>&1; then
@@ -13,36 +17,30 @@ function require_program {
 require_program "mutagen"
 require_program "jq"
 
+# Make sure the mutagen daemon is running.
+mutagen daemon start
+
 if [ "$1" == "start" ]; then
-    # Don't recreate mutagen sync if it already exists.
-    if [ -f ".ddev/.mutagen-sync-name" ]; then
-        echo "Mutagen sync appears to already be running"
+    if mutagen sync list ${project_name} 2>/dev/null; then
+        echo "Mutagen sync for ${project_name} is already running"
         exit 0
     fi
 
     # Clear out the test files that are bundled with the web container.
-    ddev exec --dir /var/www rm phpstatus.php
-    ddev exec --dir /var/www rm -r html/docroot/test
+    ddev exec --dir /var/www rm -r phpstatus.php html/test
 
-    # Make sure the mutagen daemon is running.
-    # If the daemon is already running, this will fail, but that's okay.
-    mutagen daemon start 2>/dev/null
-
-    # Create the sync process from the ddev project name
-    ddev describe -j | jq -r .raw.name > .ddev/.mutagen-sync-name
-    if ! mutagen sync list $(cat .ddev/.mutagen-sync-name) 2>/dev/null; then
-        mutagen sync create . docker://ddev-$(cat .ddev/.mutagen-sync-name)-web/var/www/html --sync-mode=two-way-resolved --symlink-mode=posix-raw --name=$(cat .ddev/.mutagen-sync-name)
-    fi
+    # Create the sync process from the ddev project
+    mutagen sync create . docker://ddev-${project_name}-web/var/www/html --sync-mode=two-way-resolved --symlink-mode=posix-raw --name=${project_name}
 
     # Wait for the initial sync process to complete, watch for errors, and return
     # when ready.
     echo "Waiting for initial sync to complete"
     while true; do
-        if mutagen sync list $(cat .ddev/.mutagen-sync-name) | grep "Last error"; then
-            echo "Mutagen sync has errored -- check 'mutagen sync list $(cat .ddev/.mutagen-sync-name)' for the problem"
+        if mutagen sync list ${project_name} | grep "Last error"; then
+            echo "Mutagen sync has errored -- check 'mutagen sync list $(cat ${mutagen_sync_file})' for the problem"
             break
         fi
-        if mutagen sync list $(cat .ddev/.mutagen-sync-name) | grep "Status: Watching for changes"; then
+        if mutagen sync list ${project_name} | grep "Status: Watching for changes" >/dev/null; then
             echo "Initial mutagen sync has completed. Happy coding!"
             break
         fi
@@ -53,6 +51,6 @@ fi
 
 if [ "$1" == "stop" ]; then
     echo "Ending mutagen sync process"
-    mutagen sync terminate $(cat .ddev/.mutagen-sync-name)
-    rm .ddev/.mutagen-sync-name
+    mutagen sync flush ${project_name}
+    mutagen sync terminate ${project_name}
 fi

--- a/mutagen
+++ b/mutagen
@@ -15,9 +15,6 @@ if ! command -v mutagen >/dev/null 2>&1; then
         exit 1
 fi
 
-# Make sure the mutagen daemon is running.
-mutagen daemon start
-
 if [ "$1" == "start" ]; then
     # If there's an existing sync, terrible things can happen, see
     # https://github.com/mutagen-io/mutagen/issues/275 and make sure that doesn't happen

--- a/setup.sh
+++ b/setup.sh
@@ -42,6 +42,9 @@ if cat .ddev/config.yaml | grep "^hooks:" > /dev/null; then
   cat << EOF
 no_project_mount: true
 hooks:
+  pre-start:
+    # Make sure we don't already have a session running; it can confuse syncing
+    - exec-host: "ddev mutagen stop"
   post-start:
     # Start the mutagen sync process for this project.
     - exec-host: "ddev mutagen start"

--- a/setup.sh
+++ b/setup.sh
@@ -32,7 +32,7 @@ no_project_mount: true
 hooks:
   pre-start:
     # Make sure we don't already have a session running; it can confuse syncing
-    - exec-host: "mutagen sync terminate \${DDEV_PROJECT}"
+    - exec-host: "mutagen sync terminate \${DDEV_PROJECT//.} 2>/dev/null || true"
   post-start:
     # Start the mutagen sync process for this project.
     - exec-host: "ddev mutagen start"

--- a/setup.sh
+++ b/setup.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 #
-# Automatically configures mutagen sync for the current .ddev project.
+# Configures mutagen sync for the current ddev project.
 #
 
 echo "=> Checking ddev project"
@@ -26,42 +26,37 @@ echo "     https://raw.githubusercontent.com/cweagans/ddev-mutagen/master/mutage
 curl -s https://raw.githubusercontent.com/cweagans/ddev-mutagen/master/mutagen > .ddev/commands/host/mutagen
 chmod +x .ddev/commands/host/mutagen
 
-# If hooks are already present, let's not break their config.
-if cat .ddev/config.yaml | grep "^hooks:" > /dev/null; then
-  echo "=> It looks like you already have active hooks in your .ddev/config.yaml."
-  echo "   To finish setup, you'll need to add/merge the following config into"
-  echo "   what you already have configured:"
-  echo
-  echo
-  cat << EOF
+# These are the hooks we need to add
+hooks=$(cat <<EOF
 no_project_mount: true
 hooks:
   pre-start:
     # Make sure we don't already have a session running; it can confuse syncing
-    - exec-host: "mutagen sync terminate ${DDEV_PROJECT}"
-  post-start:
-    # Start the mutagen sync process for this project.
-    - exec-host: "ddev mutagen start"
-  pre-stop:
-    # Terminate the mutagen sync process for this project.
-    - exec-host: "ddev mutagen stop
-EOF
-  echo
-  echo
-# Otherwise, we can safely just tack this onto the end of the .ddev/config.yaml and
-# we're good to go.
-else
-  echo "=> Setting up .ddev/config.yaml to run the mutagen sync script"
-  cat >> .ddev/config.yaml <<'config'
-no_project_mount: true
-hooks:
+    - exec-host: "mutagen sync terminate \${DDEV_PROJECT}"
   post-start:
     # Start the mutagen sync process for this project.
     - exec-host: "ddev mutagen start"
   pre-stop:
     # Terminate the mutagen sync process for this project.
     - exec-host: "ddev mutagen stop"
-config
+EOF
+)
+
+# If hooks are already present, let's not break their config.
+if cat .ddev/config.yaml | grep "^hooks:" > /dev/null; then
+  echo "=> It looks like you already have active hooks in your .ddev/config.yaml."
+  echo "   To finish setup, you'll need to add/merge the following config into"
+  echo "   what you already have configured:"
+  echo
+  echo "$hooks"
+
+  echo
+  echo
+# Otherwise, we can safely just tack this onto the end of the .ddev/config.yaml and
+# we're good to go.
+else
+  echo "=> Setting up .ddev/config.yaml to run the mutagen sync script"
+  echo "$hooks" >> .ddev/config.yaml
 fi
 
 echo

--- a/setup.sh
+++ b/setup.sh
@@ -29,6 +29,7 @@ chmod +x .ddev/commands/host/mutagen
 # These are the hooks we need to add
 hooks=$(cat <<EOF
 no_project_mount: true
+fail_on_hook_fail: true
 hooks:
   pre-start:
     # Make sure we don't already have a session running; it can confuse syncing

--- a/setup.sh
+++ b/setup.sh
@@ -3,6 +3,7 @@
 #
 # Configures mutagen sync for the current ddev project.
 #
+set -eu -o pipefail
 
 echo "=> Checking ddev project"
 if [ ! -d ".ddev" ]; then

--- a/setup.sh
+++ b/setup.sh
@@ -11,18 +11,12 @@ if [ ! -d ".ddev" ]; then
   exit 1
 fi
 
-echo "=> Checking to make sure mutagen and jq are installed"
+echo "=> Checking to make sure mutagen is installed"
 if ! type "mutagen" > /dev/null 2>&1; then
   echo "  => mutagen is not installed. running 'brew install mutagen-io/mutagen/mutagen'"
   echo "     If you do not want to do this, press Ctrl+C in the next 5 seconds"
   sleep 5
   brew install mutagen-io/mutagen/mutagen
-fi
-if ! type "jq" > /dev/null 2>&1; then
-  echo "  => jq is not installed. running 'brew install jq'"
-  echo "     If you do not want to do this, press Ctrl+C in the next 5 seconds"
-  sleep 5
-  brew install jq
 fi
 
 echo "=> Setting up mutagen sync script in the current ddev project"
@@ -44,7 +38,7 @@ no_project_mount: true
 hooks:
   pre-start:
     # Make sure we don't already have a session running; it can confuse syncing
-    - exec-host: "ddev mutagen stop"
+    - exec-host: "mutagen sync terminate ${DDEV_PROJECT}"
   post-start:
     # Start the mutagen sync process for this project.
     - exec-host: "ddev mutagen start"


### PR DESCRIPTION
I was exploring this project in preparation for exploring official mutagen.io integration for ddev. I learned a lot of things along the way, and this is the result. 

1. There's no need for a fancy file to keep track of the sync name. This does it with a simple environment variable based on $DDEV_PROJECT, and a sync name with the "." removed when it appears in a project name.
2. jq is not needed as a result. These first two items address @facine's https://github.com/cweagans/ddev-mutagen/pull/1
3. The problem with using a relative path to the .ddev directory is resolved by using an absolute path with $DDEV_APPROOT.
4. A flush is done on stop, since we don't want to just terminate
5. The sync session is killed on start if it exists, since sync names are not unique, and we could have many of them running.
6. Terminate sync session on pause to prevent #5 - `ddev pause` is a rarely used command and should probably be removed, but what would happen with "pause" is that the sync session would still exist... but have no container to run against.
7. Removed the "mutagen daemon start", as mutagen does this automatically when needed.